### PR TITLE
Add tracker model controller repo

### DIFF
--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/controllers/SymptomTrackerController.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/controllers/SymptomTrackerController.java
@@ -1,0 +1,23 @@
+package org.launchcode.trackerappbackend.controllers;
+
+import org.launchcode.trackerappbackend.data.SymptomTrackerRepository;
+import org.launchcode.trackerappbackend.models.SymptomTracker;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin(origins = "http://localhost:4200")
+@RequestMapping("symptomtracker")
+public class SymptomTrackerController {
+
+    @Autowired
+    private SymptomTrackerRepository symptomTrackerRepository;
+
+    @GetMapping("")
+    public Iterable<SymptomTracker> getSymptomTrackerData() {
+        return symptomTrackerRepository.findAll();
+    }
+}

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/data/SymptomTrackerRepository.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/data/SymptomTrackerRepository.java
@@ -1,0 +1,7 @@
+package org.launchcode.trackerappbackend.data;
+
+import org.launchcode.trackerappbackend.models.SymptomTracker;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SymptomTrackerRepository extends CrudRepository<SymptomTracker, Integer> {
+}

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/Rating.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/Rating.java
@@ -1,0 +1,26 @@
+package org.launchcode.trackerappbackend.models;
+
+public enum Rating {
+    ZERO (0),
+    ONE (1),
+    TWO (2),
+    THREE (3),
+    FOUR (4),
+    FIVE (5),
+    SIX (6),
+    SEVEN (7),
+    EIGHT (8),
+    NINE (9),
+    TEN (10);
+
+    private final int numericRating;
+
+    private Rating(int numericRating) {
+        this.numericRating = numericRating;
+    }
+
+    public int getNumericRating() {
+        return numericRating;
+    }
+
+}

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/Symptom.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/Symptom.java
@@ -5,8 +5,6 @@ import com.sun.istack.NotNull;
 import javax.persistence.*;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 
@@ -25,10 +23,6 @@ public class Symptom {
     @NotNull
     @Valid
     private User user;
-
-    // Will also need to add OneToMany relationship for Symptom to Symptom Tracker in Symptom model)
-    @OneToMany
-    private List<SymptomTracker> symptomTracker = new ArrayList<>();
 
     public Symptom(String symptomName){
         this.symptomName = symptomName;

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/Symptom.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/Symptom.java
@@ -5,6 +5,8 @@ import com.sun.istack.NotNull;
 import javax.persistence.*;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 
@@ -23,6 +25,10 @@ public class Symptom {
     @NotNull
     @Valid
     private User user;
+
+    // Will also need to add OneToMany relationship for Symptom to Symptom Tracker in Symptom model)
+    @OneToMany
+    private List<SymptomTracker> symptomTracker = new ArrayList<>();
 
     public Symptom(String symptomName){
         this.symptomName = symptomName;

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
@@ -3,6 +3,7 @@ package org.launchcode.trackerappbackend.models;
 import com.sun.istack.NotNull;
 
 import javax.persistence.*;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 
@@ -16,7 +17,7 @@ public class SymptomTracker {
     private Rating rating;
 
     @NotNull
-    private Date date;
+    private SimpleDateFormat date = new SimpleDateFormat("MM-dd-yyyy");
 
     @ManyToOne
     @NotNull
@@ -28,9 +29,11 @@ public class SymptomTracker {
 //    @NotNull
 //    private Symptom symptom;
 
+
+
     public SymptomTracker() {}
 
-    public SymptomTracker(Rating rating, Date date) {
+    public SymptomTracker(Rating rating, SimpleDateFormat date) {
         this.rating = rating;
         this.date = date;
     }
@@ -43,11 +46,11 @@ public class SymptomTracker {
         this.rating = rating;
     }
 
-    public Date getDate() {
+    public SimpleDateFormat getDate() {
         return date;
     }
 
-    public void setDate(Date date) {
+    public void setDate(SimpleDateFormat date) {
         this.date = date;
     }
 

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
@@ -2,9 +2,7 @@ package org.launchcode.trackerappbackend.models;
 
 import com.sun.istack.NotNull;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.util.Date;
 import java.util.Objects;
 
@@ -19,6 +17,16 @@ public class SymptomTracker {
 
     @NotNull
     private Date date;
+
+    @ManyToOne
+    @NotNull
+//    @Valid (will need to add in once Symptom model is merged to main, validation dependency does not exist in this branch
+    private User user;
+
+    //Once Symptom model is merged with main, will need to add ManyToOne relationship to Symptom as seen below. Will also need to add OneToMany relationship for Symptom to Symptom Tracker in Symptom model)
+//    @ManyToOne
+//    @NotNull
+//    private Symptom symptom;
 
     public SymptomTracker() {}
 

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
@@ -5,6 +5,8 @@ import com.sun.istack.NotNull;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import java.util.Date;
+import java.util.Objects;
 
 @Entity
 public class SymptomTracker {
@@ -16,11 +18,11 @@ public class SymptomTracker {
     private Rating rating;
 
     @NotNull
-    private int date;
+    private Date date;
 
     public SymptomTracker() {}
 
-    public SymptomTracker(Rating rating, int date) {
+    public SymptomTracker(Rating rating, Date date) {
         this.rating = rating;
         this.date = date;
     }
@@ -33,11 +35,24 @@ public class SymptomTracker {
         this.rating = rating;
     }
 
-    public int getDate() {
+    public Date getDate() {
         return date;
     }
 
-    public void setDate(int date) {
+    public void setDate(Date date) {
         this.date = date;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SymptomTracker that = (SymptomTracker) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
@@ -18,6 +18,7 @@ public class SymptomTracker {
 
     @NotNull
     private SimpleDateFormat date = new SimpleDateFormat("MM-dd-yyyy");
+    //if this causes issues with chart JS, we can ty changing to a Date data type; however, the SimpleDateFormat data type allows you to modify how date is formatted, which seems like it would be better with the JavaScript Date object in the client, which also allows formatting.
 
     @ManyToOne
     @NotNull

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
@@ -4,8 +4,8 @@ import com.sun.istack.NotNull;
 
 import javax.persistence.*;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Objects;
+import javax.validation.Valid;
 
 @Entity
 public class SymptomTracker {
@@ -21,14 +21,12 @@ public class SymptomTracker {
 
     @ManyToOne
     @NotNull
-//    @Valid (will need to add in once Symptom model is merged to main, validation dependency does not exist in this branch
+    @Valid
     private User user;
 
-    //Once Symptom model is merged with main, will need to add ManyToOne relationship to Symptom as seen below. Will also need to add OneToMany relationship for Symptom to Symptom Tracker in Symptom model)
-//    @ManyToOne
-//    @NotNull
-//    private Symptom symptom;
-
+    @ManyToOne
+    @NotNull
+    private Symptom symptom;
 
 
     public SymptomTracker() {}

--- a/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
+++ b/tracker-app-backend/src/main/java/org/launchcode/trackerappbackend/models/SymptomTracker.java
@@ -1,0 +1,43 @@
+package org.launchcode.trackerappbackend.models;
+
+import com.sun.istack.NotNull;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class SymptomTracker {
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private Rating rating;
+
+    @NotNull
+    private int date;
+
+    public SymptomTracker() {}
+
+    public SymptomTracker(Rating rating, int date) {
+        this.rating = rating;
+        this.date = date;
+    }
+
+    public Rating getRating() {
+        return rating;
+    }
+
+    public void setRating(Rating rating) {
+        this.rating = rating;
+    }
+
+    public int getDate() {
+        return date;
+    }
+
+    public void setDate(int date) {
+        this.date = date;
+    }
+}


### PR DESCRIPTION
Added SymptomTracker model, controller, and repository. Added relationships between symptom & symptomtracker. Added Rating model as enum class for 0-10 rating. SQL database mirrors what we had in Google docs (with one exception- each Symptomtracker has it's own id, which we didn't include in google docs table).